### PR TITLE
Implement per-meter unique checking against checksum.

### DIFF
--- a/idm/idm.go
+++ b/idm/idm.go
@@ -163,9 +163,10 @@ func (idm IDM) MeterType() uint8 {
 	return idm.ERTType
 }
 
-func (idm IDM) MeterValue() uint32 {
-	// don't know yet
-	return 0
+func (idm IDM) Checksum() []byte {
+	checksum := make([]byte, 2)
+	binary.BigEndian.PutUint16(checksum, idm.PacketCRC)
+	return checksum
 }
 
 func (idm IDM) String() string {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -50,7 +50,7 @@ type Message interface {
 	MsgType() string
 	MeterID() uint32
 	MeterType() uint8
-	MeterValue() uint32
+	Checksum() []byte
 }
 
 type LogMessage struct {

--- a/r900/r900.go
+++ b/r900/r900.go
@@ -222,6 +222,7 @@ func (p Parser) Parse(indices []int) (msgs []parse.Message) {
 		r900.Unkn3 = uint8(unkn3)
 		r900.Leak = uint8(leak)
 		r900.LeakNow = uint8(leaknow)
+		copy(r900.checksum[:], symbols[:16])
 
 		msgs = append(msgs, r900)
 	}
@@ -238,7 +239,7 @@ type R900 struct {
 	Unkn3       uint8  `xml:",attr"` // 2 bits
 	Leak        uint8  `xml:",attr"` // 4 bits, day bins of leak
 	LeakNow     uint8  `xml:",attr"` // 2 bits, leak past 24h hi/lo
-
+	checksum    [5]byte
 }
 
 func (r900 R900) MsgType() string {
@@ -253,8 +254,8 @@ func (r900 R900) MeterType() uint8 {
 	return r900.Unkn1
 }
 
-func (r900 R900) MeterValue() uint32 {
-	return r900.Consumption
+func (r900 R900) Checksum() []byte {
+	return r900.checksum[:]
 }
 
 func (r900 R900) String() string {

--- a/r900/r900.go
+++ b/r900/r900.go
@@ -222,7 +222,7 @@ func (p Parser) Parse(indices []int) (msgs []parse.Message) {
 		r900.Unkn3 = uint8(unkn3)
 		r900.Leak = uint8(leak)
 		r900.LeakNow = uint8(leaknow)
-		copy(r900.checksum[:], symbols[:16])
+		copy(r900.checksum[:], symbols[16:])
 
 		msgs = append(msgs, r900)
 	}

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -17,6 +17,7 @@
 package scm
 
 import (
+	"encoding/binary"
 	"fmt"
 	"strconv"
 
@@ -97,7 +98,7 @@ type SCM struct {
 	TamperPhy   uint8  `xml:",attr"`
 	TamperEnc   uint8  `xml:",attr"`
 	Consumption uint32 `xml:",attr"`
-	Checksum    uint16 `xml:",attr"`
+	ChecksumVal uint16 `xml:"Checksum,attr"`
 }
 
 func NewSCM(data parse.Data) (scm SCM) {
@@ -113,7 +114,7 @@ func NewSCM(data parse.Data) (scm SCM) {
 	scm.TamperPhy = uint8(tamperphy)
 	scm.TamperEnc = uint8(tamperenc)
 	scm.Consumption = uint32(consumption)
-	scm.Checksum = uint16(checksum)
+	scm.ChecksumVal = uint16(checksum)
 
 	return
 }
@@ -130,13 +131,15 @@ func (scm SCM) MeterType() uint8 {
 	return scm.Type
 }
 
-func (scm SCM) MeterValue() uint32 {
-	return scm.Consumption
+func (scm SCM) Checksum() []byte {
+	checksum := make([]byte, 2)
+	binary.BigEndian.PutUint16(checksum, scm.ChecksumVal)
+	return checksum
 }
 
 func (scm SCM) String() string {
 	return fmt.Sprintf("{ID:%8d Type:%2d Tamper:{Phy:%02X Enc:%02X} Consumption:%8d CRC:0x%04X}",
-		scm.ID, scm.Type, scm.TamperPhy, scm.TamperEnc, scm.Consumption, scm.Checksum,
+		scm.ID, scm.Type, scm.TamperPhy, scm.TamperEnc, scm.Consumption, scm.ChecksumVal,
 	)
 }
 
@@ -146,7 +149,7 @@ func (scm SCM) Record() (r []string) {
 	r = append(r, "0x"+strconv.FormatUint(uint64(scm.TamperPhy), 16))
 	r = append(r, "0x"+strconv.FormatUint(uint64(scm.TamperEnc), 16))
 	r = append(r, strconv.FormatUint(uint64(scm.Consumption), 10))
-	r = append(r, "0x"+strconv.FormatUint(uint64(scm.Checksum), 16))
+	r = append(r, "0x"+strconv.FormatUint(uint64(scm.ChecksumVal), 16))
 
 	return
 }


### PR DESCRIPTION
I've added the necessary method and implementations for each of the decoders to do per-meter unique message checking based on checksum. Merging this should include these changes in your current pull request on rtlamr.
